### PR TITLE
Add dynamic weather effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,11 +21,13 @@
             <div id="score-display">Điểm: 0</div>
             <div id="high-score-display">Điểm cao: 0</div>
             <div id="difficulty-display">Độ khó: 1</div>
+            <div id="weather-display">Thời tiết: Quang đãng</div>
         </div>
 
         <div class="pause-mute-buttons">
             <button id="pause-button">Tạm dừng</button>
             <button id="mute-button">Tắt âm</button>
+            <button id="weather-toggle">Đổi Thời Tiết</button>
         </div>
 
         <div id="countdown-display" class="hidden">3</div>


### PR DESCRIPTION
## Summary
- add weather display and toggle button
- introduce weatherState to track rain, fog, and time of day
- spawn rain particles and animate them downward
- configure fog and update skybox and directional light for time of day
- cycle weather automatically by score or manually via button or `W` key

## Testing
- `node -c main.js`

------
https://chatgpt.com/codex/tasks/task_e_684429a6ffec8321ae178d6ef650f3fd